### PR TITLE
Update to latest libauth (2.0.0-alpha.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@bitauth/libauth": "2.0.0-alpha.6",
+    "@bitauth/libauth": "2.0.0-alpha.8",
     "@bitauth/react-scripts-bitauth-ide": "^5.0.1-patch2",
     "@blueprintjs/core": "^4.3.1",
     "@blueprintjs/select": "^4.2.1",

--- a/src/editor/script-editor/bch-language.ts
+++ b/src/editor/script-editor/bch-language.ts
@@ -289,6 +289,14 @@ export const signatureOperationParameterDescriptions: {
     'A.K.A. "SIGHASH_ALL" (Recommended)',
     'The recommended and most frequently used signing serialization algorithm. This signs each element of the transaction using the private key, preventing an attacker from being able to reuse the signature on a modified transaction.',
   ],
+  all_outputs_all_utxos: [
+    'A.K.A. `SIGHASH_ALL|SIGHASH_UTXOS|SIGHASH_FORKID`',
+    ''
+  ],
+  all_outputs_single_input_INVALID_all_utxos: [
+    'A.K.A. `SIGHASH_ALL|SIGHASH_UTXOS|SIGHASH_FORKID|ANYONECANPAY`',
+    ''
+  ],
   all_outputs_single_input: [
     'A.K.A. "SIGHASH_ALL" with "ANYONE_CAN_PAY"',
     'A modification to the "all_outputs" signing serialization algorithm which does not cover inputs other than the one being spent.',
@@ -297,17 +305,42 @@ export const signatureOperationParameterDescriptions: {
     'A.K.A. "SIGHASH_SINGLE"',
     'A signing serialization algorithm which only covers the output with the same index value as the input being spent. Warning: this can cause vulnerabilities by allowing the transaction to be modified after being signed.',
   ],
+  corresponding_output_all_utxos: [
+    'A.K.A. `SIGHASH_SINGLE|SIGHASH_UTXOS|SIGHASH_FORKID`',
+    ''
+  ],
   corresponding_output_single_input: [
     'A.K.A. "SIGHASH_SINGLE" with "ANYONE_CAN_PAY"',
     'A modification to the "corresponding_output" signing serialization algorithm which does not cover inputs other than the one being spent.',
+  ],
+  corresponding_output_single_input_INVALID_all_utxos: [
+    'A.K.A. `SIGHASH_SINGLE|SIGHASH_UTXOS|SIGHASH_FORKID|ANYONECANPAY`',
+    ''
+  ],
+  default: [
+    'An alias for `all_outputs_all_utxos`\n'+
+    '(A.K.A. `SIGHASH_ALL|SIGHASH_UTXOS|SIGHASH_FORKID`),\n'+
+    'the most secure signing serialization algorithm.\n'+
+    'Note that as of 2022, `all_outputs` (A.K.A. `SIGHASH_ALL|SIGHASH_FORKID`)\n'+
+    'is more commonly used and is therefore a better choice for privacy in\n'+
+    'common, existing contract types.',
+    ''
   ],
   no_outputs: [
     'A.K.A. "SIGHASH_NONE"',
     'A signing serialization algorithm which only covers other inputs. Warning: this allows anyone to modify the outputs after being signed.',
   ],
+  no_outputs_all_utxos: [
+    'A.K.A `SIGHASH_NONE|SIGHASH_UTXOS|SIGHASH_FORKID`',
+    ''
+  ],
   no_outputs_single_input: [
     'A.K.A. "SIGHASH_NONE" with "ANYONE_CAN_PAY"',
     'A modification to the "no_outputs" signing serialization algorithm which does not cover inputs other than the one being spent.',
+  ],
+  no_outputs_single_input_INVALID_all_utxos: [
+    'A.K.A. `SIGHASH_NONE|SIGHASH_UTXOS|SIGHASH_FORKID|ANYONECANPAY`',
+    ''
   ],
 };
 
@@ -358,6 +391,35 @@ export const signingSerializationOperationDetails: {
     | CompilerOperationsSigningSerializationComponent
     | CompilerOperationsSigningSerializationFull]: [string, string];
 } = {
+  full_all_outputs_all_utxos: [
+    'full_all_outputs_all_utxos',
+    ''
+  ],
+  full_all_outputs_single_input_INVALID_all_utxos: [
+    'full_all_outputs_single_input_INVALID_all_utxos',
+    ''
+  ],
+  full_corresponding_output_all_utxos: [
+    'full_corresponding_output_all_utxos',
+    ''
+  ],
+  full_default: [
+    'full_default',
+    ''
+  ],
+  full_no_outputs_all_utxos: [
+    'full_no_outputs_all_utxos',
+    ''
+  ],
+  full_corresponding_output_single_input_INVALID_all_utxos: [
+    'full_corresponding_output_single_input_INVALID_all_utxos',
+    ''
+  ],
+  full_no_outputs_single_input_INVALID_all_utxos: [
+    'full_no_outputs_single_input_INVALID_all_utxos',
+    ''
+  ],
+
   corresponding_output: [
     'Corresponding Output',
     'The signing serialization of the transaction output with the same index as the current input. If no output with the same index exists, this inserts no bytes.',

--- a/src/editor/script-editor/error-assistance.tsx
+++ b/src/editor/script-editor/error-assistance.tsx
@@ -54,7 +54,7 @@ export const vmErrorAssistanceBCH: {
               </p>
               <ol>
                 {state.signedMessages.map((message, index) => {
-                  const hex = binToHex(message);
+                  const hex = binToHex(message.digest);
                   return (
                     <li key={index} className="error-signed-message-list-item">
                       <Popover

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,10 +1063,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitauth/libauth@2.0.0-alpha.6":
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@bitauth/libauth/-/libauth-2.0.0-alpha.6.tgz#92f951afa23ac0f29409d2d38409bc7584b002df"
-  integrity sha512-YyrTKr2svYNFZilsdIFru037aRiqDO5J/MrG7KpKHVi21B+Nu+u9oUWFM5GGVdYRb+SIkqryUm/UwgfxrSmKqw==
+"@bitauth/libauth@2.0.0-alpha.8":
+  version "2.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@bitauth/libauth/-/libauth-2.0.0-alpha.8.tgz#352ade2075517f1548e05553e7bb1c5e1023d1fe"
+  integrity sha512-KINAJbzg5pKs+WM8wCjWw6Ct/CeZG1JMrRXsIyPFztjNtwA5eeQL8eFkyquePsf8aZ5peRYK2eFPUDo/1rkg+w==
 
 "@bitauth/react-scripts-bitauth-ide@^5.0.1-patch2":
   version "5.0.1-patch2"


### PR DESCRIPTION
Signing inputs that spend tokens now works. Pat said there's still some help info missing.